### PR TITLE
Add flushTQueue, flushTBQueue

### DIFF
--- a/Control/Concurrent/STM/TQueue.hs
+++ b/Control/Concurrent/STM/TQueue.hs
@@ -38,6 +38,7 @@ module Control.Concurrent.STM.TQueue (
         newTQueueIO,
         readTQueue,
         tryReadTQueue,
+        flushTQueue,
         peekTQueue,
         tryPeekTQueue,
         writeTQueue,
@@ -105,6 +106,18 @@ readTQueue (TQueue read write) = do
 -- returns @Nothing@ if no value is available.
 tryReadTQueue :: TQueue a -> STM (Maybe a)
 tryReadTQueue c = fmap Just (readTQueue c) `orElse` return Nothing
+
+-- | Efficiently read the entire contents of a 'TQueue' into a list. This
+-- function never retries.
+--
+-- @since TBD
+flushTQueue :: TQueue a -> STM [a]
+flushTQueue (TQueue read write) = do
+  xs <- readTVar read
+  ys <- readTVar write
+  writeTVar read []
+  writeTVar write []
+  return (xs ++ reverse ys)
 
 -- | Get the next value from the @TQueue@ without removing it,
 -- retrying if the channel is empty.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog for [`stm` package](http://hackage.haskell.org/package/stm)
 
+## TBD
+
+  * Add `flushTQueue` to `Control.Concurrent.STM.TQueue`
+
+  * Add `flushTBQueue` to `Control.Concurrent.STM.TBQueue`
+
 ## 2.4.4.1  *Dec 2015*
 
   * Add support for `base-4.9.0.0`


### PR DESCRIPTION
Here's a convenience function I've wanted before in the past, and it's much more efficient than:

```haskell
flushTQueue :: TQueue a -> STM [a]
flushTQueue xs = do
  mx <- tryReadTQueue xs
  case mx of
    Nothing -> return []
    Just x -> fmap (x:) (flushTQueue xs)
```

Thanks!