### PR TITLE
TChan documentation newBroadcastTChan example

### DIFF
--- a/Control/Concurrent/STM/TChan.hs
+++ b/Control/Concurrent/STM/TChan.hs
@@ -86,7 +86,7 @@ newTChanIO = do
 --
 -- >serve :: TChan Message -> Client -> IO loop
 -- >serve broadcastChan client = do
--- >    myChan <- dupTChan broadcastChan
+-- >    myChan <- atomically $ dupTChan broadcastChan
 -- >    forever $ do
 -- >        message <- readTChan myChan
 -- >        send client message

--- a/Control/Concurrent/STM/TChan.hs
+++ b/Control/Concurrent/STM/TChan.hs
@@ -88,7 +88,7 @@ newTChanIO = do
 -- >serve broadcastChan client = do
 -- >    myChan <- atomically $ dupTChan broadcastChan
 -- >    forever $ do
--- >        message <- readTChan myChan
+-- >        message <- atomically $ readTChan myChan
 -- >        send client message
 --
 -- The problem with using 'newTChan' to create the broadcast channel is that if


### PR DESCRIPTION
Current example currently does not work as dupTChan runs inside the STM monad, not IO