### PR TITLE
Bump base upper bound to 4.16

### DIFF
--- a/stm.cabal
+++ b/stm.cabal
@@ -50,7 +50,7 @@ library
         build-depends: nats (>= 0.1.3 && < 0.3) || (>= 1 && < 1.2)
 
     build-depends:
-        base  >= 4.3 && < 4.16,
+        base  >= 4.3 && < 4.17,
         array >= 0.3 && < 0.6
 
     exposed-modules:


### PR DESCRIPTION
Context: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4082#note_300462