### PR TITLE
Adding writeTMVar

### DIFF
--- a/Control/Concurrent/STM/TMVar.hs
+++ b/Control/Concurrent/STM/TMVar.hs
@@ -148,6 +148,11 @@ swapTMVar (TMVar t) new = do
     Nothing -> retry
     Just old -> do writeTVar t (Just new); return old
 
+-- | Non-blocking write of a new value to a 'TMVar'
+-- Puts if empty. Replaces if populated.
+writeTMVar :: TMVar a -> a -> STM a
+writeTMVar t new = tryTakeTMVar t *> putTMVar t new
+
 -- |Check whether a given 'TMVar' is empty.
 isEmptyTMVar :: TMVar a -> STM Bool
 isEmptyTMVar (TMVar t) = do

--- a/Control/Concurrent/STM/TMVar.hs
+++ b/Control/Concurrent/STM/TMVar.hs
@@ -30,6 +30,7 @@ module Control.Concurrent.STM.TMVar (
         takeTMVar,
         putTMVar,
         readTMVar,
+        writeTMVar,
         tryReadTMVar,
         swapTMVar,
         tryTakeTMVar,
@@ -151,7 +152,7 @@ swapTMVar (TMVar t) new = do
 -- | Non-blocking write of a new value to a 'TMVar'
 -- Puts if empty. Replaces if populated.
 writeTMVar :: TMVar a -> a -> STM ()
-writeTMVar t new = tryTakeTMVar t *> putTMVar t new
+writeTMVar t new = tryTakeTMVar t >> putTMVar t new
 
 -- |Check whether a given 'TMVar' is empty.
 isEmptyTMVar :: TMVar a -> STM Bool

--- a/Control/Concurrent/STM/TMVar.hs
+++ b/Control/Concurrent/STM/TMVar.hs
@@ -150,7 +150,7 @@ swapTMVar (TMVar t) new = do
 
 -- | Non-blocking write of a new value to a 'TMVar'
 -- Puts if empty. Replaces if populated.
-writeTMVar :: TMVar a -> a -> STM a
+writeTMVar :: TMVar a -> a -> STM ()
 writeTMVar t new = tryTakeTMVar t *> putTMVar t new
 
 -- |Check whether a given 'TMVar' is empty.


### PR DESCRIPTION
Adding a `writeTMVar` function that immediately writes to a TMVar.

Useful for modelling a producer/consumer type pattern where the producer can always write immediately, and the consumer waits for the value to be populated. This way the consumer always gets the most recently produced value.

Let me know if this isn't the right place for such a function!