### PR TITLE
Bump testsuite base depends

### DIFF
--- a/testsuite/testsuite.cabal
+++ b/testsuite/testsuite.cabal
@@ -36,7 +36,7 @@ test-suite stm
 
   --
   build-depends:
-    , base                   >= 4.3 && < 4.14
+    , base                   >= 4.3 && < 4.17
     , test-framework        ^>= 0.8.2.0
     , test-framework-hunit  ^>= 0.3.0.2
     , HUnit                 ^>= 1.6.0.0


### PR DESCRIPTION
I presume this is correct. The same bump seems to have happened to `stm.cabal`.