### PR TITLE
Prohibit builds with GHC 7.0

### DIFF
--- a/stm.cabal
+++ b/stm.cabal
@@ -50,7 +50,7 @@ library
         build-depends: nats (>= 0.1.3 && < 0.3) || (>= 1 && < 1.2)
 
     build-depends:
-        base  >= 4.3 && < 4.17,
+        base  >= 4.4 && < 4.17,
         array >= 0.3 && < 0.6
 
     exposed-modules:


### PR DESCRIPTION
GHC 7.0 builds are broken because of
https://github.com/haskell/stm/blob/d4b9a893762f131dcd80fcab0180a7a575581e2d/stm.cabal#L69

See https://matrix.hackage.haskell.org/#/package/stm/2.5.0.2/ghc-7.0.4@1639080451 for test evidence. I put a revision to plug this on Hackage: https://hackage.haskell.org/package/stm-2.5.0.2/revisions/

One can restore support of GHC 7.0 by putting `-fwarn-incomplete-uni-patterns` under `if impl(ghc >= 7.2)`, but I assume that maintainers do not have much interest to test against GHC 7.0:
https://github.com/haskell/stm/blob/d4b9a893762f131dcd80fcab0180a7a575581e2d/stm.cabal#L14