### PR TITLE
mark stm055, T16707 as broken for JS

### DIFF
--- a/tests/all.T
+++ b/tests/all.T
@@ -5,7 +5,7 @@ test('stm048', [], compile_and_run, [''])
 test('stm050', [extra_run_opts('10000')], compile_and_run, ['-package stm'])
 
 test('stm054', normal, compile_and_run, ['-package stm'])
-test('stm055', exit_code(1), compile_and_run, ['-package stm'])
+test('stm055', [exit_code(1), js_broken(22576)], compile_and_run, ['-package stm'])
 test('stm056', only_ways(['threaded1','threaded2']),
                 compile_and_run, ['-package stm'])
 
@@ -16,4 +16,4 @@ test('stm065', normal, compile_and_run, ['-package stm'])
 test('cloneTChan001', normal, compile_and_run, ['-package stm'])
 
 test('T15136', extra_run_opts('20'), compile_and_run, ['-package stm'])
-test('T16707', normal, compile_and_run, [''])
+test('T16707', js_broken(22576), compile_and_run, [''])


### PR DESCRIPTION
This is blocking the CI for the JS backend, tracked [here](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/9552). This is basically the same PR that was applied to [hpc](https://gitlab.haskell.org/hpc/hpc/-/merge_requests/21) and [process](https://github.com/haskell/process/pull/268)