### PR TITLE
Fix strictness of `stateTVar`

### DIFF
--- a/Control/Concurrent/STM/TVar.hs
+++ b/Control/Concurrent/STM/TVar.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, MagicHash, UnboxedTuples #-}
+{-# LANGUAGE BangPatterns, CPP, MagicHash, UnboxedTuples #-}
 
 #if __GLASGOW_HASKELL__ >= 701
 {-# LANGUAGE Trustworthy #-}
@@ -73,7 +73,7 @@ modifyTVar' var f = do
 stateTVar :: TVar s -> (s -> (a, s)) -> STM a
 stateTVar var f = do
    s <- readTVar var
-   let (a, s') = f s -- since we destructure this, we are strict in f
+   let !(a, s') = f s
    writeTVar var s'
    return a
 {-# INLINE stateTVar #-}

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog for [`stm` package](http://hackage.haskell.org/package/stm)
 
+## Upcoming
+
+  * Fix strictness of `stateTVar` ([#69](https://github.com/haskell/stm/pull/69))
+
 ## 2.5.1.0 *Aug 2022*
 
   * Teach `flushTBQueue` to only flush queue when necessary


### PR DESCRIPTION
Closes #30.

This was intended to be strict (see https://github.com/haskell/stm/issues/30#issuecomment-658466992).