### PR TITLE
Update tests for CLC proposal: Modify displayed exception type

### DIFF
--- a/tests/stm055.stderr
+++ b/tests/stm055.stderr
@@ -1,1 +1,7 @@
-stm055: Control.Concurrent.STM.atomically was nested
+stm055: Exception:
+
+Control.Concurrent.STM.atomically was nested
+
+Package: ghc-internal
+Module: GHC.Internal.Control.Exception.Base
+Type: NestedAtomically


### PR DESCRIPTION
Now that the CLC proposal has been approved, this can be merged.

https://github.com/haskell/core-libraries-committee/issues/261.

See https://gitlab.haskell.org/ghc/ghc/-/merge_requests/12242.

Obviates https://github.com/haskell/stm/pull/81.