### PR TITLE
readTQueueN

### DIFF
--- a/Control/Concurrent/STM/TQueue.hs
+++ b/Control/Concurrent/STM/TQueue.hs
@@ -121,8 +121,8 @@ readTQueue (TQueue read write) = do
 -- case 4: Like case 3 but prepend read onto return value
 
 -- |Reads N values, blocking until enough are available
-readTQueueN :: Int -> TQueue a -> STM [a]
-readTQueueN n (TQueue read write) = do
+readTQueueN :: TQueue a -> Int -> STM [a]
+readTQueueN (TQueue read write) n = do
   xs <- readTVar read
   let xl = length xs
   if xl > n then do -- case 1a

--- a/stm.cabal
+++ b/stm.cabal
@@ -1,6 +1,6 @@
 cabal-version:  >=1.10
 name:           stm
-version:        2.5.3.1
+version:        2.5.4
 -- don't forget to update changelog.md file!
 
 license:        BSD3

--- a/testsuite/src/Main.hs
+++ b/testsuite/src/Main.hs
@@ -10,6 +10,7 @@ import qualified Issue17
 import qualified Stm052
 import qualified Stm064
 import qualified Stm065
+import qualified Stm066
 
 main :: IO ()
 main = do
@@ -23,6 +24,7 @@ main = do
         , testCase "stm052" Stm052.main
         , testCase "stm064" Stm064.main
         , testCase "stm065" Stm065.main
+        , testCase "stm066" Stm066.main
         ]
       ]
 

--- a/testsuite/src/Stm066.hs
+++ b/testsuite/src/Stm066.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE CPP #-}
+
+{- NB: This one fails for GHC < 7.6 which had a bug exposed via
+       nested uses of `orElse` in `stmCommitNestedTransaction`
+
+This was fixed in GHC via
+ f184d9caffa09750ef6a374a7987b9213d6db28e
+-}
+
+module Stm066 (main) where
+
+import           Control.Concurrent
+import           Control.Concurrent.STM
+import           Control.Concurrent.STM.TQueue
+import           Control.Monad          (unless)
+
+main :: IO ()
+main = do
+  q <- atomically $ newTQueue
+  _ <- forkIO $ atomically $ do
+    writeTQueue q (1::Int)
+    writeTQueue q 2
+    writeTQueue q 3
+    writeTQueue q 4
+  l <- atomically $ do
+         _ <- readTQueueN 1 q 
+         readTQueueN 3 q 
+
+  unless (l == [2,3,4]) $
+    fail (show l)

--- a/testsuite/src/Stm066.hs
+++ b/testsuite/src/Stm066.hs
@@ -23,8 +23,8 @@ main = do
     writeTQueue q 3
     writeTQueue q 4
   l <- atomically $ do
-         _ <- readTQueueN 1 q 
-         readTQueueN 3 q 
+         _ <- readTQueueN q 1 
+         readTQueueN q 3 
 
   unless (l == [2,3,4]) $
     fail (show l)

--- a/testsuite/testsuite.cabal
+++ b/testsuite/testsuite.cabal
@@ -37,6 +37,7 @@ test-suite stm
     Stm052
     Stm064
     Stm065
+    Stm066
 
   type: exitcode-stdio-1.0
 


### PR DESCRIPTION
This function retries until N items are available in a TQueue without removing them, and then returns them all at once. In some cases a small `<>` happens, but if the calling code is left to do this the performance cost is higher. It also becomes quite messy and is almost tantamount to reimplementing a queue in front of the queue.