### PR TITLE
Bump bounds to support GHC 9.12 and 9.14

### DIFF
--- a/bench/stm-bench.cabal
+++ b/bench/stm-bench.cabal
@@ -25,6 +25,6 @@ tested-with:
 benchmark chanbench
     type:             exitcode-stdio-1.0
     main-is:          ChanBench.hs
-    build-depends:    base >= 4.9 && < 4.21, stm, async >= 2.0, tasty, tasty-bench
+    build-depends:    base >= 4.9 && < 4.22, stm, async >= 2.0, tasty, tasty-bench
     default-language: Haskell2010
     ghc-options:      -O2 -threaded -with-rtsopts=-N

--- a/bench/stm-bench.cabal
+++ b/bench/stm-bench.cabal
@@ -25,6 +25,6 @@ tested-with:
 benchmark chanbench
     type:             exitcode-stdio-1.0
     main-is:          ChanBench.hs
-    build-depends:    base >= 4.9 && < 4.22, stm, async >= 2.0, tasty, tasty-bench
+    build-depends:    base >= 4.9 && < 4.23, stm, async >= 2.0, tasty, tasty-bench
     default-language: Haskell2010
     ghc-options:      -O2 -threaded -with-rtsopts=-N

--- a/stm.cabal
+++ b/stm.cabal
@@ -66,7 +66,7 @@ library
         build-depends: semigroups >=0.18.6 && <0.21
 
     build-depends:
-        base  >= 4.4 && < 4.22,
+        base  >= 4.4 && < 4.23,
         array >= 0.3 && < 0.6
 
     exposed-modules:

--- a/stm.cabal
+++ b/stm.cabal
@@ -66,7 +66,7 @@ library
         build-depends: semigroups >=0.18.6 && <0.21
 
     build-depends:
-        base  >= 4.4 && < 4.21,
+        base  >= 4.4 && < 4.22,
         array >= 0.3 && < 0.6
 
     exposed-modules:

--- a/testsuite/testsuite.cabal
+++ b/testsuite/testsuite.cabal
@@ -49,7 +49,7 @@ test-suite stm
 
   --
   build-depends:
-    , base                   >= 4.4 && < 4.21
+    , base                   >= 4.4 && < 4.22
     , test-framework        ^>= 0.8.2.0
     , test-framework-hunit  ^>= 0.3.0.2
     , HUnit                 ^>= 1.6.0.0

--- a/testsuite/testsuite.cabal
+++ b/testsuite/testsuite.cabal
@@ -49,7 +49,7 @@ test-suite stm
 
   --
   build-depends:
-    , base                   >= 4.4 && < 4.22
+    , base                   >= 4.4 && < 4.23
     , test-framework        ^>= 0.8.2.0
     , test-framework-hunit  ^>= 0.3.0.2
     , HUnit                 ^>= 1.6.0.0


### PR DESCRIPTION
The GHC 9.12 bump has been released as a revision. The 9.14 bump will need to happen once the 9.14 release is cut.