### PR TITLE
add some 'IO' variants

### DIFF
--- a/Control/Concurrent/STM/TMVar.hs
+++ b/Control/Concurrent/STM/TMVar.hs
@@ -32,10 +32,12 @@ module Control.Concurrent.STM.TMVar (
         readTMVar,
         writeTMVar,
         tryReadTMVar,
+        tryReadTMVarIO,
         swapTMVar,
         tryTakeTMVar,
         tryPutTMVar,
         isEmptyTMVar,
+        isEmptyTMVarIO,
         mkWeakTMVar
 #endif
   ) where
@@ -141,6 +143,19 @@ readTMVar (TMVar t) = do
 tryReadTMVar :: TMVar a -> STM (Maybe a)
 tryReadTMVar (TMVar t) = readTVar t
 
+-- | A version of 'readTMVar' which does not retry. This is
+-- equivalent to
+--
+-- >  readTVarIO = atomically . readTVar
+--
+-- but works much faster, because it doesn't perform a complete
+-- transaction, it just attempts to read the current value of
+-- the 'TMVar'.
+-- 
+-- @since 2.5.4.0
+tryReadTMVarIO :: TMVar a -> IO (Maybe a)
+tryReadTMVarIO (TMVar t) = readTVarIO t
+
 -- |Swap the contents of a 'TMVar' for a new value.
 swapTMVar :: TMVar a -> a -> STM a
 swapTMVar (TMVar t) new = do
@@ -160,6 +175,16 @@ writeTMVar (TMVar t) new = writeTVar t (Just new)
 isEmptyTMVar :: TMVar a -> STM Bool
 isEmptyTMVar (TMVar t) = do
   m <- readTVar t
+  case m of
+    Nothing -> return True
+    Just _  -> return False
+
+-- | @IO@ version of 'isEmptyTVar'.
+-- 
+-- @since 2.5.4.0
+isEmptyTMVarIO :: TMVar a -> IO Bool
+isEmptyTMVarIO (TMVar t) = do
+  m <- readTVarIO t
   case m of
     Nothing -> return True
     Just _  -> return False

--- a/Control/Concurrent/STM/TSem.hs
+++ b/Control/Concurrent/STM/TSem.hs
@@ -17,6 +17,7 @@
 module Control.Concurrent.STM.TSem
   ( TSem
   , newTSem
+  , newTSemIO
 
   , waitTSem
 
@@ -58,6 +59,12 @@ newtype TSem = TSem (TVar Integer)
 -- @since 2.4.2
 newTSem :: Integer -> STM TSem
 newTSem i = fmap TSem (newTVar $! i)
+
+-- | @IO@ equivalent of 'newTSem'.
+--
+-- @since 2.5.4.0
+newTSemIO :: Integer -> IO TSem
+newTSemIO i = fmap TSem (newTVarIO $! i)
 
 -- NOTE: we can't expose a good `TSem -> STM Int' operation as blocked
 -- 'waitTSem' aren't reliably reflected in a negative counter value.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog for [`stm` package](http://hackage.haskell.org/package/stm)
 
+## 2.5.4.0 *Apr 2026*
+
+  * Add `IO` variants for operations that don't need to retry ([#94](https://github.com/haskell/stm/pull/94))
+
 ## 2.5.3.1 *Apr 2024*
 
   * Drop unused testcase inadvertently introduced in previous reversion

--- a/stm.cabal
+++ b/stm.cabal
@@ -66,7 +66,7 @@ library
         build-depends: semigroups >=0.18.6 && <0.21
 
     build-depends:
-        base  >= 4.4 && < 4.23,
+        base  >= 4.4 && < 4.24,
         array >= 0.3 && < 0.6
 
     exposed-modules:

--- a/testsuite/testsuite.cabal
+++ b/testsuite/testsuite.cabal
@@ -14,9 +14,11 @@ description:
   See also @README.md@ for more information.
 
 tested-with:
-  GHC == 9.10.1
-  GHC == 9.8.2
-  GHC == 9.6.4
+  GHC == 9.14.1
+  GHC == 9.12.4
+  GHC == 9.10.3
+  GHC == 9.8.4
+  GHC == 9.6.7
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
@@ -49,7 +51,7 @@ test-suite stm
 
   --
   build-depends:
-    , base                   >= 4.4 && < 4.23
+    , base                   >= 4.4 && < 4.24
     , test-framework        ^>= 0.8.2.0
     , test-framework-hunit  ^>= 0.3.0.2
     , HUnit                 ^>= 1.6.0.0


### PR DESCRIPTION
## description

* 'tryReadTMVarIO': a faster 'tryReadTMVar' (doesn't need to retry)
* 'isEmptyTMVarIO': a faster 'isEmptyTMVar' (doesn't need to retry)
* 'newTSemIO': 'newTSem' that can be run in 'unsafePerformIO'

### notes

closes https://github.com/haskell/stm/issues/89